### PR TITLE
snisnoop: really simplify snisnoop-ebpf's implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
-# papaya-tools
-Experimental collection of eBPF / aya utilities
+# papaya-tools 🔨🦀🐝🍍
+Experimental collection of eBPF / aya / network / system / tracing utilities
 
 ### Tools
 
+| Tool Name    | Description                           |
+|--------------|---------------------------------------|
+| [profile-bee](https://github.com/zz85/profile-bee/)  | CPU profiling                         |
+| [tcc-trace](https://github.com/zz85/tcc-trace)    | Peek at congestion control changes    |
+| [snisnoop](snisnoop)     | Find outgoing TLS domains             |
+
+
 #### snisnoop - short for TLS SNI (Server Name Indication) Snoop.
 
-```
-Example: sudo snisnoop --interface eth0
+```bash
+Example:
+$ sudo snisnoop --interface eth0
 
-TIME         PID      SOURCE                 DESTINATION            SNI                           
+TIME         PID      SOURCE                 DESTINATION            SNI
 ----------------------------------------------------------------------------------------------
-10:03:50     8548     172.19.192.80:42464    74.6.143.25:443        yahoo.com                     
-10:03:56     8737     172.19.192.80:34792    172.217.14.206:443     google.com                    
-10:04:08     9049     172.19.192.80:60278    3.163.24.19:443        aws.com                       
+10:03:50     8548     172.19.192.80:42464    74.6.143.25:443        yahoo.com
+10:03:56     8737     172.19.192.80:34792    172.217.14.206:443     google.com
+10:04:08     9049     172.19.192.80:60278    3.163.24.19:443        aws.com
 ```
 
 Finds out what outgoing TLS connections host is making.
@@ -25,7 +33,7 @@ https://github.com/zz85/packet_radar/blob/master/src/bin/ja4dump.rs
 
 #### tcc trace (traffic congestion control trace)
 
-```
+```bash
 $ sudo target/release/tcc-trace --port 443
 
 Filtering port: 443
@@ -37,4 +45,15 @@ Waiting for Ctrl-C...
 ```
 
 Uses Tracepoint to find congestion control parameters set by the OS
-See https://github.com/zz85/tcc-trace
+
+#### Ideas cooking..
+- spawnsnoop - find out processes that launch, similar to execsnoop
+- connection drop catcher - find out connections are dropping because process are too busy
+- tracepoint-snisnoop - but implmennted with tracepoint
+- implement sni parser in ebpf rather than user space
+- publish this as a crate
+
+#### Links
+- https://github.com/iovisor/bcc/
+- https://github.com/aya-rs/awesome-aya
+

--- a/snisnoop/snisnoop-ebpf/src/main.rs
+++ b/snisnoop/snisnoop-ebpf/src/main.rs
@@ -4,10 +4,10 @@
 use aya_ebpf::{
     bindings::TC_ACT_PIPE,
     cty::c_long,
-    helpers::{bpf_get_current_task, bpf_probe_read_kernel, bpf_skb_load_bytes},
+    helpers::{bpf_get_current_task, bpf_probe_read_kernel},
     macros::{classifier, map},
     maps::RingBuf,
-    programs::{sk_buff::SkBuff, TcContext},
+    programs::TcContext,
 };
 use aya_log_ebpf::debug;
 use network_types::{
@@ -33,35 +33,9 @@ pub fn snisnoop(ctx: TcContext) -> i32 {
     }
 }
 
-// Probably still buggy
 #[inline]
-pub fn load_bytes2(skb: &SkBuff, offset: usize, dst: &mut [u8]) -> Result<usize, c_long> {
-    let buffer_len = dst.len();
-    let sk_len = skb.len() as usize;
-    let lesser_len = buffer_len.min(skb.len() as usize);
-    // these checks doesn't help the verifier :(
-    // if sk_len == 0 || sk_len >= buffer_len {
-    //     return Err(0);
-    // }
-
-    let ret = unsafe {
-        bpf_skb_load_bytes(
-            skb.skb as *const _,
-            offset as u32,
-            dst.as_mut_ptr() as *mut _,
-            buffer_len as u32,
-        )
-    };
-    if ret == 0 {
-        Ok(lesser_len)
-    } else {
-        Err(ret)
-    }
-}
-
-#[inline]
-fn get_process_id(ctx: &TcContext) -> Result<u32, i64> {
-    // todo: get associated process ID
+fn get_process_id() -> Result<u32, i64> {
+    // get associated process ID
     // unfortuantely, bpf_get_current_pid_tgid() only works in Linux 6.10
     // see https://docs.ebpf.io/linux/helper-function/bpf_get_current_pid_tgid/
     // so we need to use bpf_get_current_task(), but we'll need the structs
@@ -82,53 +56,23 @@ fn copy_data_to_userspace(ctx: &TcContext) {
     if let Some(mut buf) = DATA.reserve::<RawPacket>(0) {
         let packet = unsafe { buf.assume_init_mut() };
 
-        // fixme: ideally, we should be able to use ctx.load_bytes(0, &mut packet.data)
-        // but ebpf verifier have just been erroring on that
-        // example: https://github.com/iovisor/bcc/issues/3269
-
-        // if let Ok(len) = load_bytes2(&ctx.skb, 0, &mut packet.data) {
-        //     info!(ctx, "load_bytes2 ok len: {}", len);
-        //     packet.len = ctx.len() as u32;
-        //     buf.submit(0);
-        // } else {
-        //     info!(ctx, "load_bytes failed");
-        //     buf.discard(0);
-        // }
-
-        // Looping statically and copying each byte seems to yield the best results
-        for i in 0..packet.data.len() {
-            if let Ok(v) = ctx.load::<u8>(i as usize) {
-                packet.data[i] = v;
-                packet.len = i as u32 + 1;
-            } else {
-                break;
-            }
+        // let ebpf verifier know that there's at least a single byte in skbuff's data
+        // which would be a requirement for bpf_skb_load_bytes() to work
+        if ctx.len() < 2 {
+            buf.discard(0);
+            return;
         }
 
-        if let Ok(tgid) = get_process_id(ctx) {
+        if let Ok(len) = ctx.load_bytes(0, &mut packet.data) {
+            packet.len = len as u32;
+        }
+
+        if let Ok(tgid) = get_process_id() {
             packet.tgid = tgid;
         }
 
-        /*
-        // This is rather strange - there's no errors, but after parsing tcp, payload seems to be filled with zeros
-        unsafe {
-            let len = packet.data.len().min(ctx.len() as usize);
-            if let Ok(_) = aya_ebpf::helpers::bpf_probe_read_kernel_buf(
-                ctx.data() as *const _,
-                &mut packet.data[0..len],
-            ) {
-                // if let Ok(_) = aya_ebpf::helpers::bpf_probe_read_user_buf(ctx.data() as *const u8, &mut packet.data) {
-                // if let Ok(_) = aya_ebpf::helpers::bpf_probe_read_buf(ctx.data() as *const u8, &mut packet.data[..len]) {
-                packet.len = len as u32;
-            }
-        }*/
-
         // usage of RingBufEntry requires us to submit or discard after reserving
-        if packet.len > 0 {
-            buf.submit(0);
-        } else {
-            buf.discard(0);
-        }
+        buf.submit(0);
     }
 }
 


### PR DESCRIPTION
- previously I used a bounded for loop to get around ebpf verification errors. turns out that under the hood  skb_ctx.load() still used the same ebpf helper bpf_skb_load_bytes()
- I also learnt that bpf_probe_read_kernel_buf() doesn't work even though ether, ip, tcp headers get's copied correctly is because the data buffers are likely stored in a different memory location
- lastly, what really need to get .load_bytes() to work for ensuring that the skbuff length was more than 1. this fix could probably be upstreamed to aya

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and reformatted the README with a more detailed introduction, a tools table, clearer examples, output tables, and additional sections for tool ideas and external links.

- **Refactor**
  - Simplified packet data loading and process ID retrieval logic for improved clarity and efficiency.
  - Removed unused imports and a redundant helper function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->