### PR TITLE
quicsnoop: QUIC Initial Packet Client Hello Parsing and Extraction via eBPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Experimental collection of eBPF / aya / network / system / tracing utilities
 | [profile-bee](https://github.com/zz85/profile-bee/)  | CPU profiling                         |
 | [tcc-trace](https://github.com/zz85/tcc-trace)    | Peek at congestion control changes    |
 | [snisnoop](snisnoop)     | Find processes and domains for outgoing TLS handshakes             |
-
+| [quicsnoop](quicsnoop)     | Find SNI of initial QUIC packets                 |
 
 #### snisnoop - short for TLS SNI (Server Name Indication) Snoop.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Experimental collection of eBPF / aya / network / system / tracing utilities
 |--------------|---------------------------------------|
 | [profile-bee](https://github.com/zz85/profile-bee/)  | CPU profiling                         |
 | [tcc-trace](https://github.com/zz85/tcc-trace)    | Peek at congestion control changes    |
-| [snisnoop](snisnoop)     | Find outgoing TLS domains             |
+| [snisnoop](snisnoop)     | Find processes and domains for outgoing TLS handshakes             |
 
 
 #### snisnoop - short for TLS SNI (Server Name Indication) Snoop.

--- a/quicsnoop/Cargo.toml
+++ b/quicsnoop/Cargo.toml
@@ -1,0 +1,33 @@
+[workspace]
+resolver = "2"
+members = [
+    "quicsnoop",
+    "quicsnoop-common",
+    "quicsnoop-ebpf",
+]
+default-members = ["quicsnoop", "quicsnoop-common"]
+
+[workspace.package]
+license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+aya = { version = "0.13.1", default-features = false }
+aya-build = { version = "0.1.2", default-features = false }
+aya-ebpf = { version = "0.1.1", default-features = false }
+aya-log = { version = "0.2.1", default-features = false }
+aya-log-ebpf = { version = "0.1.1", default-features = false }
+
+anyhow = { version = "1", default-features = false }
+# `std` feature is currently required to build `clap`.
+#
+# See https://github.com/clap-rs/clap/blob/61f5ee5/clap_builder/src/lib.rs#L15.
+clap = { version = "4.5.20", default-features = false, features = ["std"] }
+env_logger = { version = "0.11.5", default-features = false }
+libc = { version = "0.2.159", default-features = false }
+log = { version = "0.4.22", default-features = false }
+tokio = { version = "1.40.0", default-features = false }
+which = { version = "6.0.0", default-features = false }
+
+[profile.release.package.quicsnoop-ebpf]
+debug = 2
+codegen-units = 1

--- a/quicsnoop/LICENSE-APACHE
+++ b/quicsnoop/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright {yyyy} Authors of bpfman.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+   limitations under the License.

--- a/quicsnoop/LICENSE-GPL2
+++ b/quicsnoop/LICENSE-GPL2
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/quicsnoop/LICENSE-MIT
+++ b/quicsnoop/LICENSE-MIT
@@ -1,0 +1,21 @@
+Copyright (c) 2021 Alessandro Decina
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/quicsnoop/README.md
+++ b/quicsnoop/README.md
@@ -1,0 +1,57 @@
+# quicsnoop
+
+## Prerequisites
+
+1. stable rust toolchains: `rustup toolchain install stable`
+1. nightly rust toolchains: `rustup toolchain install nightly --component rust-src`
+1. (if cross-compiling) rustup target: `rustup target add ${ARCH}-unknown-linux-musl`
+1. (if cross-compiling) LLVM: (e.g.) `brew install llvm` (on macOS)
+1. (if cross-compiling) C toolchain: (e.g.) [`brew install filosottile/musl-cross/musl-cross`](https://github.com/FiloSottile/homebrew-musl-cross) (on macOS)
+1. bpf-linker: `cargo install bpf-linker` (`--no-default-features` on macOS)
+
+## Build & Run
+
+Use `cargo build`, `cargo check`, etc. as normal. Run your program with:
+
+```shell
+cargo run --release --config 'target."cfg(all())".runner="sudo -E"'
+```
+
+Cargo build scripts are used to automatically build the eBPF correctly and include it in the
+program.
+
+## Cross-compiling on macOS
+
+Cross compilation should work on both Intel and Apple Silicon Macs.
+
+```shell
+CC=${ARCH}-linux-musl-gcc cargo build --package quicsnoop --release \
+  --target=${ARCH}-unknown-linux-musl \
+  --config=target.${ARCH}-unknown-linux-musl.linker=\"${ARCH}-linux-musl-gcc\"
+```
+The cross-compiled program `target/${ARCH}-unknown-linux-musl/release/quicsnoop` can be
+copied to a Linux server or VM and run there.
+
+## License
+
+With the exception of eBPF code, quicsnoop is distributed under the terms
+of either the [MIT license] or the [Apache License] (version 2.0), at your
+option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this crate by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.
+
+### eBPF
+
+All eBPF code is distributed under either the terms of the
+[GNU General Public License, Version 2] or the [MIT license], at your
+option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the GPL-2 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[Apache license]: LICENSE-APACHE
+[MIT license]: LICENSE-MIT
+[GNU General Public License, Version 2]: LICENSE-GPL2

--- a/quicsnoop/quicsnoop-common/Cargo.toml
+++ b/quicsnoop/quicsnoop-common/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "quicsnoop-common"
+version = "0.1.0"
+edition = "2021"
+
+license.workspace = true
+
+[features]
+default = []
+user = ["aya"]
+
+[dependencies]
+aya = { workspace = true, optional = true }
+
+[lib]
+path = "src/lib.rs"

--- a/quicsnoop/quicsnoop-common/src/lib.rs
+++ b/quicsnoop/quicsnoop-common/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+use core::mem;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct QuicPacket {
+    /// Fix size allocation for packet data
+    pub data: [u8; 3000],
+    pub len: u32,
+}
+
+impl QuicPacket {
+    pub const LEN: usize = mem::size_of::<QuicPacket>();
+}

--- a/quicsnoop/quicsnoop-common/src/lib.rs
+++ b/quicsnoop/quicsnoop-common/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::mem;
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct QuicPacket {
     /// Fix size allocation for packet data
@@ -11,5 +11,5 @@ pub struct QuicPacket {
 }
 
 impl QuicPacket {
-    pub const LEN: usize = mem::size_of::<QuicPacket>();
+    pub const STRUCT_SIZE: usize = mem::size_of::<QuicPacket>();
 }

--- a/quicsnoop/quicsnoop-ebpf/Cargo.toml
+++ b/quicsnoop/quicsnoop-ebpf/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "quicsnoop-ebpf"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+quicsnoop-common = { path = "../quicsnoop-common" }
+
+aya-ebpf = { workspace = true }
+aya-log-ebpf = { workspace = true }
+network-types = "0.0.8"
+
+[build-dependencies]
+which = { workspace = true }
+
+[[bin]]
+name = "quicsnoop"
+path = "src/main.rs"

--- a/quicsnoop/quicsnoop-ebpf/build.rs
+++ b/quicsnoop/quicsnoop-ebpf/build.rs
@@ -1,0 +1,17 @@
+use which::which;
+
+/// Building this crate has an undeclared dependency on the `bpf-linker` binary. This would be
+/// better expressed by [artifact-dependencies][bindeps] but issues such as
+/// https://github.com/rust-lang/cargo/issues/12385 make their use impractical for the time being.
+///
+/// This file implements an imperfect solution: it causes cargo to rebuild the crate whenever the
+/// mtime of `which bpf-linker` changes. Note that possibility that a new bpf-linker is added to
+/// $PATH ahead of the one used as the cache key still exists. Solving this in the general case
+/// would require rebuild-if-changed-env=PATH *and* rebuild-if-changed={every-directory-in-PATH}
+/// which would likely mean far too much cache invalidation.
+///
+/// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
+fn main() {
+    let bpf_linker = which("bpf-linker").unwrap();
+    println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+}

--- a/quicsnoop/quicsnoop-ebpf/src/lib.rs
+++ b/quicsnoop/quicsnoop-ebpf/src/lib.rs
@@ -1,0 +1,109 @@
+#![no_std]
+
+use aya_ebpf::macros::map;
+use aya_ebpf::maps::RingBuf;
+use aya_ebpf::programs::TcContext;
+use aya_log_ebpf::info;
+use network_types::{
+    eth::{EthHdr, EtherType},
+    ip::{IpProto, Ipv4Hdr, Ipv6Hdr},
+    udp::UdpHdr,
+};
+use quicsnoop_common::QuicPacket;
+
+const QUIC_LONG_PACKET_TYPE_MASK: u8 = 0x30;
+
+#[map]
+static DATA: RingBuf = RingBuf::with_byte_size(1000 * QuicPacket::LEN as u32, 0);
+
+#[inline]
+pub fn parse_packet(ctx: &TcContext) -> Result<bool, i64> {
+    let ethhdr: EthHdr = ctx.load(0)?;
+
+    match ethhdr.ether_type {
+        EtherType::Ipv4 => {
+            let header = ctx.load::<Ipv4Hdr>(EthHdr::LEN)?;
+
+            match header.proto {
+                IpProto::Udp => {
+                    let src = header.src_addr();
+                    let dst = header.dst_addr();
+                    let udp: UdpHdr = ctx.load(EthHdr::LEN + Ipv4Hdr::LEN)?;
+                    let src_port = udp.source();
+                    let dst_port = udp.dest();
+
+                    let flag: u8 = ctx.load(EthHdr::LEN + Ipv4Hdr::LEN + UdpHdr::LEN)?;
+
+                    // TODO confirm calculation
+                    let parse = flag & QUIC_LONG_PACKET_TYPE_MASK == 0;
+
+                    info!(
+                        ctx,
+                        "ipv4 src {}:{} -> {}:{} flag: {}, parse: {}",
+                        src,
+                        src_port,
+                        dst,
+                        dst_port,
+                        flag,
+                        parse as u8
+                    );
+
+                    let ret = copy_data_to_userspace(&ctx);
+
+                    info!(ctx, "len {} - {}", ctx.len(), ret as u8);
+                }
+                _ => return Ok(false),
+            };
+        }
+        EtherType::Ipv6 => {
+            let header = ctx.load::<Ipv6Hdr>(EthHdr::LEN)?;
+
+            match header.next_hdr {
+                IpProto::Udp => {
+                    let dst = header.dst_addr();
+                    let src = header.src_addr();
+                    let udp: UdpHdr = ctx.load(EthHdr::LEN + Ipv6Hdr::LEN)?;
+                    let src_port = udp.source();
+                    let dst_port = udp.dest();
+
+                    let flag: u8 = ctx.load(EthHdr::LEN + Ipv4Hdr::LEN + UdpHdr::LEN)?;
+
+                    info!(
+                        ctx,
+                        "ipv6 src {}:{} -> {}:{} flag: {}", src, src_port, dst, dst_port, flag
+                    );
+
+                    copy_data_to_userspace(&ctx);
+                }
+                _ => return Ok(false),
+            };
+        }
+        _ => return Ok(false),
+    }
+
+    Ok(true)
+}
+
+#[inline]
+fn copy_data_to_userspace(ctx: &TcContext) -> bool {
+    let Some(mut buf) = DATA.reserve::<QuicPacket>(0) else {
+        return false;
+    };
+
+    let packet = unsafe { buf.assume_init_mut() };
+
+    // let ebpf verifier know that there's at least a single byte in skbuff's data
+    // which would be a requirement for bpf_skb_load_bytes() to work
+    if ctx.len() < 2 {
+        buf.discard(0);
+        return false;
+    }
+
+    if let Ok(len) = ctx.load_bytes(0, &mut packet.data) {
+        packet.len = len as u32;
+    }
+
+    // usage of RingBufEntry requires us to submit or discard after reserving
+    buf.submit(0);
+    true
+}

--- a/quicsnoop/quicsnoop-ebpf/src/lib.rs
+++ b/quicsnoop/quicsnoop-ebpf/src/lib.rs
@@ -14,7 +14,7 @@ use quicsnoop_common::QuicPacket;
 const QUIC_LONG_PACKET_TYPE_MASK: u8 = 0x30;
 
 #[map]
-static DATA: RingBuf = RingBuf::with_byte_size(1000 * QuicPacket::LEN as u32, 0);
+static DATA: RingBuf = RingBuf::with_byte_size(1000 * QuicPacket::STRUCT_SIZE as u32, 0);
 
 #[inline]
 pub fn parse_packet(ctx: &TcContext) -> Result<bool, i64> {

--- a/quicsnoop/quicsnoop-ebpf/src/lib.rs
+++ b/quicsnoop/quicsnoop-ebpf/src/lib.rs
@@ -48,7 +48,7 @@ pub fn parse_packet(ctx: &TcContext) -> Result<bool, i64> {
                         parse as u8
                     );
 
-                    let ret = copy_data_to_userspace(&ctx);
+                    let ret = copy_data_to_userspace(ctx);
 
                     info!(ctx, "len {} - {}", ctx.len(), ret as u8);
                 }
@@ -73,7 +73,7 @@ pub fn parse_packet(ctx: &TcContext) -> Result<bool, i64> {
                         "ipv6 src {}:{} -> {}:{} flag: {}", src, src_port, dst, dst_port, flag
                     );
 
-                    copy_data_to_userspace(&ctx);
+                    copy_data_to_userspace(ctx);
                 }
                 _ => return Ok(false),
             };

--- a/quicsnoop/quicsnoop-ebpf/src/main.rs
+++ b/quicsnoop/quicsnoop-ebpf/src/main.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{bindings::TC_ACT_PIPE, macros::classifier, programs::TcContext};
+use aya_log_ebpf::info;
+use quicsnoop_ebpf::parse_packet;
+
+#[classifier]
+pub fn quicsnoop(ctx: TcContext) -> i32 {
+    match try_quicsnoop(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_quicsnoop(ctx: TcContext) -> Result<i32, i32> {
+    // info!(&ctx, "received a packet");
+
+    let _ = parse_packet(&ctx);
+    Ok(TC_ACT_PIPE)
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[link_section = "license"]
+#[no_mangle]
+static LICENSE: [u8; 13] = *b"Dual MIT/GPL\0";

--- a/quicsnoop/quicsnoop/Cargo.toml
+++ b/quicsnoop/quicsnoop/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "quicsnoop"
+version = "0.1.0"
+edition = "2021"
+
+license.workspace = true
+
+[dependencies]
+quicsnoop-common = { path = "../quicsnoop-common", features = ["user"] }
+
+anyhow = { workspace = true, default-features = true }
+aya = { workspace = true }
+aya-log = { workspace = true }
+env_logger = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true, features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "net",
+    "signal",
+] }
+clap = { workspace = true, features = ["derive"] }
+etherparse = "0.18.0"
+s2n-quic-core = "0.58.0"
+s2n-codec = "0.58.0"
+s2n-quic-crypto = "0.58.0"
+[build-dependencies]
+anyhow = { workspace = true }
+aya-build = { workspace = true }
+# TODO(https://github.com/rust-lang/cargo/issues/12375): this should be an artifact dependency, but
+# it's not possible to tell cargo to use `-Z build-std` to build it. We cargo-in-cargo in the build
+# script to build this, but we want to teach cargo about the dependecy so that cache invalidation
+# works properly.
+#
+# Note also that https://github.com/rust-lang/cargo/issues/10593 occurs when `target = ...` is added
+# to an artifact dependency; it seems possible to work around that by setting `resolver = "1"` in
+# Cargo.toml in the workspace root.
+#
+# Finally note that *any* usage of `artifact = ...` in *any* Cargo.toml in the workspace breaks
+# workflows with stable cargo; stable cargo outright refuses to load manifests that use unstable
+# features.
+quicsnoop-ebpf = { path = "../quicsnoop-ebpf" }
+
+[[bin]]
+name = "quicsnoop"
+path = "src/main.rs"

--- a/quicsnoop/quicsnoop/Cargo.toml
+++ b/quicsnoop/quicsnoop/Cargo.toml
@@ -26,6 +26,7 @@ etherparse = "0.18.0"
 s2n-quic-core = "0.58.0"
 s2n-codec = "0.58.0"
 s2n-quic-crypto = "0.58.0"
+tls-parser = "0.12.2"
 [build-dependencies]
 anyhow = { workspace = true }
 aya-build = { workspace = true }

--- a/quicsnoop/quicsnoop/Cargo.toml
+++ b/quicsnoop/quicsnoop/Cargo.toml
@@ -27,6 +27,7 @@ s2n-quic-core = "0.58.0"
 s2n-codec = "0.58.0"
 s2n-quic-crypto = "0.58.0"
 tls-parser = "0.12.2"
+quick_cache = "0.6.14"
 [build-dependencies]
 anyhow = { workspace = true }
 aya-build = { workspace = true }

--- a/quicsnoop/quicsnoop/build.rs
+++ b/quicsnoop/quicsnoop/build.rs
@@ -1,0 +1,14 @@
+use anyhow::{anyhow, Context as _};
+use aya_build::cargo_metadata;
+
+fn main() -> anyhow::Result<()> {
+    let cargo_metadata::Metadata { packages, .. } = cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        .exec()
+        .context("MetadataCommand::exec")?;
+    let ebpf_package = packages
+        .into_iter()
+        .find(|cargo_metadata::Package { name, .. }| name == "quicsnoop-ebpf")
+        .ok_or_else(|| anyhow!("quicsnoop-ebpf package not found"))?;
+    aya_build::build_ebpf([ebpf_package])
+}

--- a/quicsnoop/quicsnoop/src/main.rs
+++ b/quicsnoop/quicsnoop/src/main.rs
@@ -1,0 +1,92 @@
+use aya::{
+    maps::RingBuf,
+    programs::{tc, SchedClassifier, TcAttachType},
+};
+use clap::Parser;
+#[rustfmt::skip]
+use log::{debug, warn};
+use quicsnoop_common::QuicPacket;
+use tokio::signal;
+
+mod quic;
+
+#[derive(Debug, Parser)]
+struct Opt {
+    #[clap(short, long, default_value = "eth0")]
+    iface: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let opt = Opt::parse();
+
+    env_logger::init();
+
+    // Bump the memlock rlimit. This is needed for older kernels that don't use the
+    // new memcg based accounting, see https://lwn.net/Articles/837122/
+    let rlim = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlim) };
+    if ret != 0 {
+        debug!("remove limit on locked memory failed, ret is: {ret}");
+    }
+
+    // This will include your eBPF object file as raw bytes at compile-time and load it at
+    // runtime. This approach is recommended for most real-world use cases. If you would
+    // like to specify the eBPF program at runtime rather than at compile-time, you can
+    // reach for `Bpf::load_file` instead.
+    let mut ebpf = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
+        env!("OUT_DIR"),
+        "/quicsnoop"
+    )))?;
+    if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
+        // This can happen if you remove all log statements from your eBPF program.
+        warn!("failed to initialize eBPF logger: {e}");
+    }
+    let Opt { iface } = opt;
+    // error adding clsact to the interface if it is already added is harmless
+    // the full cleanup can be done with 'sudo tc qdisc del dev eth0 clsact'.
+    let _ = tc::qdisc_add_clsact(&iface);
+    let program: &mut SchedClassifier = ebpf.program_mut("quicsnoop").unwrap().try_into()?;
+    program.load()?;
+    program.attach(&iface, TcAttachType::Ingress)?;
+
+    // Receive packets
+    tokio::spawn(async move {
+        let ring_buf = RingBuf::try_from(ebpf.map_mut("DATA").unwrap()).unwrap();
+        use tokio::io::unix::AsyncFd;
+        let mut fd = AsyncFd::new(ring_buf).unwrap();
+
+        while let Ok(mut guard) = fd.readable_mut().await {
+            match guard.try_io(|inner| {
+                let ring_buf = inner.get_mut();
+                while let Some(item) = ring_buf.next() {
+                    let raw: &QuicPacket = unsafe {
+                        let ptr = item.as_ptr() as *const QuicPacket;
+                        &*ptr
+                    };
+
+                    let data = &raw.data[..raw.len as usize];
+
+                    println!("User space received Raw packet with length: {}", raw.len);
+                }
+                Ok(())
+            }) {
+                Ok(_) => {
+                    guard.clear_ready();
+                    continue;
+                }
+                Err(_would_block) => continue,
+            }
+        }
+    });
+
+    let ctrl_c = signal::ctrl_c();
+    println!("Waiting for Ctrl-C...");
+    ctrl_c.await?;
+    println!("Exiting...");
+
+    Ok(())
+}

--- a/quicsnoop/quicsnoop/src/main.rs
+++ b/quicsnoop/quicsnoop/src/main.rs
@@ -3,6 +3,7 @@ use aya::{
     programs::{tc, SchedClassifier, TcAttachType},
 };
 use clap::Parser;
+use log::info;
 #[rustfmt::skip]
 use log::{debug, warn};
 use crate::network::parse_ether;
@@ -73,8 +74,8 @@ async fn main() -> anyhow::Result<()> {
 
                     let data = &raw.data[..raw.len as usize];
 
-                    println!("User space received Raw packet with length: {}", raw.len);
-                    parse_ether(data);
+                    info!("User space received Raw packet with length: {}", raw.len);
+                    let _ = parse_ether(data);
                 }
                 Ok(())
             }) {

--- a/quicsnoop/quicsnoop/src/network.rs
+++ b/quicsnoop/quicsnoop/src/network.rs
@@ -4,12 +4,6 @@ use crate::quic::decode_quic_initial_packet;
 
 pub fn parse_ether(packet: &[u8]) -> Result<(), &str> {
     let ether = SlicedPacket::from_ethernet(packet).map_err(|_e| "cannot parse ethernet frame")?;
-
-    // println!("link: {:?}", ether.link); // mac address
-    // println!("link_exts: {:?}", ether.link_exts); // vlan & macsec
-    // println!("net: {:?}", ether.net); // ip & arp
-    // println!("transport: {:?}", ether.transport); // udp
-
     let net = ether.net.ok_or("no net layer")?;
 
     if !net.is_ip() {
@@ -21,54 +15,39 @@ pub fn parse_ether(packet: &[u8]) -> Result<(), &str> {
         return Err("not udp");
     };
 
+    let source_port = udp.source_port();
+    let destination_port = udp.destination_port();
+
+    let payload = udp.payload();
+    let sni = decode_quic_initial_packet(payload).ok_or("unable to decode quic inital packet")?;
+
     if net.is_ipv4() {
-        println!("IPv4");
         let ipv4 = net.ipv4_ref().ok_or("no ipv4")?;
         let destination = ipv4.header().destination_addr();
         let source = ipv4.header().source_addr();
-        println!("IPv4 source: {}", source);
-        println!("IPv4 destination: {}", destination);
+        println!(
+            "IPv4 {}:{} -> {}:{}",
+            source, source_port, destination, destination_port
+        );
     } else if net.is_ipv6() {
-        println!("IPv6");
         let ipv6 = net.ipv6_ref().ok_or("no ipv4")?;
         let destination = ipv6.header().destination_addr();
         let source = ipv6.header().source_addr();
-        println!("IPv6 source: {}", source);
-        println!("IPv6 destination: {}", destination);
+        println!(
+            "IPv6 {}:{} -> {}:{}",
+            source, source_port, destination, destination_port
+        );
     }
 
-    println!("UDP {:?}", udp.to_header());
+    // println!("UDP {:?}", udp.to_header());
 
-    let source_port = udp.source_port();
-    let destination_port = udp.destination_port();
-    let length = udp.length();
-
-    println!("UDP source port: {}", source_port);
-    println!("UDP destination port: {}", destination_port);
-    println!("UDP length: {}", length);
-
-    let payload = udp.payload();
-
-    println!("UDP payload {:?}", &payload[0..10]);
-
-    println!(
-        "IP {:?}",
-        &net.ip_payload_ref().ok_or("no ip payload")?.payload[0..12]
-    );
-
-    let res = decode_quic_initial_packet(payload);
-
-    println!("QUIC {:?}", res);
-
-    // let ether_type = ether.payload_ether_type().ok_or("no ether type");
+    // println!("UDP payload {:?}", &payload[0..10]);
+    // println!(
+    //     "IP {:?}",
+    //     &net.ip_payload_ref().ok_or("no ip payload")?.payload[0..12]
+    // );
 
     // let ip_payload = ether.ip_payload().ok_or("ip")?;
-
-    // let ether = ether
-    //     .ether_payload()
-    //     .ok_or("no payload in ethernet frame")?;
-
-    // let ip = SlicedPacket::from_ip(ether.payload).map_err(|_e| "cannot parse IP frame")?;
 
     Ok(())
 }

--- a/quicsnoop/quicsnoop/src/network.rs
+++ b/quicsnoop/quicsnoop/src/network.rs
@@ -26,27 +26,24 @@ pub fn parse_ether(packet: &[u8]) -> Result<(), &str> {
         let destination = ipv4.header().destination_addr();
         let source = ipv4.header().source_addr();
         println!(
-            "IPv4 {}:{} -> {}:{}",
-            source, source_port, destination, destination_port
+            "IPv4 {}:{} -> {}:{}. SNI: {}",
+            source, source_port, destination, destination_port, sni
         );
     } else if net.is_ipv6() {
         let ipv6 = net.ipv6_ref().ok_or("no ipv4")?;
         let destination = ipv6.header().destination_addr();
         let source = ipv6.header().source_addr();
         println!(
-            "IPv6 {}:{} -> {}:{}",
-            source, source_port, destination, destination_port
+            "IPv6 {}:{} -> {}:{}. SNI {}",
+            source, source_port, destination, destination_port, sni
         );
     }
 
     // println!("UDP {:?}", udp.to_header());
-
-    // println!("UDP payload {:?}", &payload[0..10]);
     // println!(
     //     "IP {:?}",
     //     &net.ip_payload_ref().ok_or("no ip payload")?.payload[0..12]
     // );
-
     // let ip_payload = ether.ip_payload().ok_or("ip")?;
 
     Ok(())

--- a/quicsnoop/quicsnoop/src/network.rs
+++ b/quicsnoop/quicsnoop/src/network.rs
@@ -1,0 +1,74 @@
+use etherparse::SlicedPacket;
+
+use crate::quic::decode_quic_initial_packet;
+
+pub fn parse_ether(packet: &[u8]) -> Result<(), &str> {
+    let ether = SlicedPacket::from_ethernet(packet).map_err(|_e| "cannot parse ethernet frame")?;
+
+    // println!("link: {:?}", ether.link); // mac address
+    // println!("link_exts: {:?}", ether.link_exts); // vlan & macsec
+    // println!("net: {:?}", ether.net); // ip & arp
+    // println!("transport: {:?}", ether.transport); // udp
+
+    let net = ether.net.ok_or("no net layer")?;
+
+    if !net.is_ip() {
+        return Err("not ip");
+    }
+
+    let transport = ether.transport.ok_or("no transport layer")?;
+    let etherparse::TransportSlice::Udp(udp) = transport else {
+        return Err("not udp");
+    };
+
+    if net.is_ipv4() {
+        println!("IPv4");
+        let ipv4 = net.ipv4_ref().ok_or("no ipv4")?;
+        let destination = ipv4.header().destination_addr();
+        let source = ipv4.header().source_addr();
+        println!("IPv4 source: {}", source);
+        println!("IPv4 destination: {}", destination);
+    } else if net.is_ipv6() {
+        println!("IPv6");
+        let ipv6 = net.ipv6_ref().ok_or("no ipv4")?;
+        let destination = ipv6.header().destination_addr();
+        let source = ipv6.header().source_addr();
+        println!("IPv6 source: {}", source);
+        println!("IPv6 destination: {}", destination);
+    }
+
+    println!("UDP {:?}", udp.to_header());
+
+    let source_port = udp.source_port();
+    let destination_port = udp.destination_port();
+    let length = udp.length();
+
+    println!("UDP source port: {}", source_port);
+    println!("UDP destination port: {}", destination_port);
+    println!("UDP length: {}", length);
+
+    let payload = udp.payload();
+
+    println!("UDP payload {:?}", &payload[0..10]);
+
+    println!(
+        "IP {:?}",
+        &net.ip_payload_ref().ok_or("no ip payload")?.payload[0..12]
+    );
+
+    let res = decode_quic_initial_packet(payload);
+
+    println!("QUIC {:?}", res);
+
+    // let ether_type = ether.payload_ether_type().ok_or("no ether type");
+
+    // let ip_payload = ether.ip_payload().ok_or("ip")?;
+
+    // let ether = ether
+    //     .ether_payload()
+    //     .ok_or("no payload in ethernet frame")?;
+
+    // let ip = SlicedPacket::from_ip(ether.payload).map_err(|_e| "cannot parse IP frame")?;
+
+    Ok(())
+}

--- a/quicsnoop/quicsnoop/src/network.rs
+++ b/quicsnoop/quicsnoop/src/network.rs
@@ -44,7 +44,7 @@ pub fn parse_ether(packet: &[u8]) -> Result<QuicPacketInfo, &str> {
         return Err("unsupported IP protocol");
     };
 
-    log::info!(
+    println!(
         "{} {}:{} -> {}:{}. SNI: {}",
         if net.is_ipv4() { "IPv4" } else { "IPv6" },
         source_ip,

--- a/quicsnoop/quicsnoop/src/quic.rs
+++ b/quicsnoop/quicsnoop/src/quic.rs
@@ -12,6 +12,7 @@ use s2n_quic_core::{
 
 pub fn decode_quic_initial_packet(packet: &[u8]) -> Option<()> {
     let mut data = [0; 1500];
+    println!("QUIC Packet len {}", packet.len());
     let decode_buffer = &mut data[..packet.len()];
     decode_buffer.copy_from_slice(packet);
 
@@ -45,14 +46,14 @@ pub fn decode_quic_initial_packet(packet: &[u8]) -> Option<()> {
     let clear_initial = intial_encrypted
         .decrypt(&initial_key)
         .map_err(|err| {
-            // info!("cannot decrypt {err}");
+            info!("cannot decrypt {err}");
             // just move on if we can't decrypt packet
         })
         .ok()?;
 
     let packet_number = clear_initial.packet_number;
-    let dcid = clear_initial.destination_connection_id().to_vec();
-    let scid = clear_initial.source_connection_id().to_vec();
+    let dcid = clear_initial.destination_connection_id();
+    let scid = clear_initial.source_connection_id();
 
     debug!("QUIC Packet version {version}. #{packet_number}. scid {scid:02x?} -> dcid {dcid:02x?}");
 

--- a/quicsnoop/quicsnoop/src/quic.rs
+++ b/quicsnoop/quicsnoop/src/quic.rs
@@ -1,0 +1,140 @@
+use log::{debug, info};
+use s2n_codec::DecoderBufferMut;
+use s2n_quic_core::{
+    connection::id::ConnectionInfo,
+    crypto::InitialKey,
+    frame::{Crypto, Frame, FrameMut},
+    inet::SocketAddress,
+    packet::ProtectedPacket,
+};
+
+// imported from https://github.com/zz85/packet_radar/commit/3bfd50ebe3b3e0a3077843ec40746dfcc7ec7053
+
+pub fn decode_quic_initial_packet(packet: &[u8]) -> Option<()> {
+    let mut data = [0; 1500];
+    let decode_buffer = &mut data[..packet.len()];
+    decode_buffer.copy_from_slice(packet);
+
+    let payload = DecoderBufferMut::new(decode_buffer);
+    let remote_address = SocketAddress::default();
+    let connection_info = ConnectionInfo::new(&remote_address);
+
+    let (packet, _remaining) = ProtectedPacket::decode(payload, &connection_info, &0).ok()?;
+
+    let version = packet.version()?;
+
+    // care only about initial packets
+    let protected_packet = match packet {
+        ProtectedPacket::Initial(packet) => packet,
+        _ => {
+            return None;
+        }
+    };
+
+    let (initial_key, initial_header_key) = s2n_quic_crypto::initial::InitialKey::new_server(
+        protected_packet.destination_connection_id(),
+    );
+
+    let intial_encrypted = protected_packet
+        .unprotect(&initial_header_key, Default::default())
+        .map_err(|e| {
+            info!("cannot unprotect {e}");
+        })
+        .ok()?;
+
+    let clear_initial = intial_encrypted
+        .decrypt(&initial_key)
+        .map_err(|err| {
+            // info!("cannot decrypt {err}");
+            // just move on if we can't decrypt packet
+        })
+        .ok()?;
+
+    let packet_number = clear_initial.packet_number;
+    let dcid = clear_initial.destination_connection_id().to_vec();
+    let scid = clear_initial.source_connection_id().to_vec();
+
+    debug!("QUIC Packet version {version}. #{packet_number}. scid {scid:02x?} -> dcid {dcid:02x?}");
+
+    let mut payload = clear_initial.payload;
+    //QUIC_CACHE.get(&dcid).unwrap_or(
+    let mut crypto = CryptoAssembler::new();
+
+    // iterate frames from the QUIC packet
+    while !payload.is_empty() {
+        let (frame, remaining) = payload.decode::<FrameMut>().unwrap();
+        if let Frame::Crypto(frame) = frame {
+            // handle_crypto_frame
+            crypto.add_frame(frame);
+        }
+
+        payload = remaining;
+    }
+
+    if crypto.completed() {
+        println!("QUIC Crypto completed");
+        // let (_, msg) = parse_tls_message_handshake(crypto.get_bytes())
+        //     .map_err(|e| info!("Cannot parse {e:?}"))
+        //     .ok()?;
+
+        // if let TlsMessage::Handshake(TlsMessageHandshake::ClientHello(client_hello)) = msg {
+        //     let ch = process_client_hello(client_hello);
+
+        //     info!("QUIC {ch:?}");
+        //     return Some(ch);
+        // }
+    } else {
+        // QUIC_CACHE.insert(dcid, crypto);
+    }
+
+    None
+}
+
+/// we should probably use s2n_quic_core::buffer::Reassembler
+/// as this is something simple, doesn't check duplicate bytes range
+/// but could do for now
+#[derive(Clone, Debug)]
+struct CryptoAssembler {
+    // up to 64k support
+    crypto: [u8; 1 << 16],
+    size: usize,
+    recv: usize,
+}
+
+impl CryptoAssembler {
+    fn new() -> Self {
+        Self {
+            crypto: [0u8; 1 << 16],
+            size: 0,
+            recv: 0,
+        }
+    }
+    fn add_frame(&mut self, frame: Crypto<DecoderBufferMut>) {
+        let slice = frame.data.as_less_safe_slice();
+        let offset = frame.offset.as_u64() as usize;
+        let to = offset + slice.len();
+
+        debug!("received: {offset}..{to}");
+
+        self.crypto[offset..to].copy_from_slice(slice);
+        // let's expect the first 4 bytes to be together
+        if offset == 0 && to > 2 {
+            let target: u32 = ((self.crypto[1] as u32) << 16)
+                + ((self.crypto[2] as u32) << 8)
+                + self.crypto[3] as u32;
+            self.size = target as usize + 4;
+            debug!("matched 4 bytes {:x} - {target}", self.crypto[0]);
+        }
+
+        self.recv += slice.len();
+    }
+
+    fn get_bytes(&self) -> &[u8] {
+        &self.crypto[..self.size]
+    }
+
+    fn completed(&self) -> bool {
+        debug!("QUIC Crypto completed: {}/{}", self.recv, self.size);
+        self.size > 0 && self.recv == self.size
+    }
+}

--- a/quicsnoop/rustfmt.toml
+++ b/quicsnoop/rustfmt.toml
@@ -1,0 +1,4 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+reorder_imports = true
+unstable_features = true


### PR DESCRIPTION
## Summary
This PR introduces a new tool, quicsnoop, for extracting Server Name Indication (SNI) from QUIC Initial packets using eBPF.  This is similar to the snisnoop tool which works for TCP but for not QUIC

### Features
- eBPF classifier parses Ethernet, IPv4/IPv6, and UDP headers, identifies QUIC packets, and copies packet data to userspace.
- Userspace Rust application loads and attaches the eBPF program, receives packets via a ring buffer, and parses QUIC Initial packets to extract SNI.
- Caching and reassembly of QUIC crypto frames to handle fragmented ClientHello messages.
- Command-line interface for selecting network interface and egress/ingress direction.
- Logging and error handling for both eBPF and userspace components.

Notes
- Only QUIC Initial packets are parsed for SNI
- Currently breaks for ClientHello (eg. those with Post-Quantium Keys) that spans multiple packets (requires further work to unprotect subsequent packets it seems)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `quicsnoop` tool for capturing and decoding QUIC initial packets to extract Server Name Indication (SNI).
  - Support for both IPv4 and IPv6 traffic with live packet capture and SNI extraction.
  - Command-line options added for specifying network interface and direction (ingress/egress).
  - Added detailed QUIC packet parsing and assembly logic for TLS ClientHello extraction.
  - Integrated eBPF programs for efficient packet filtering and user-space communication.

- **Documentation**
  - Added comprehensive README files for `quicsnoop` and updated `snisnoop` descriptions.
  - Included detailed setup, build, usage instructions, and licensing information.

- **Chores**
  - Added license files for MIT, Apache 2.0, and GPLv2.
  - Added Rust workspace, project manifests, and build scripts.
  - Added Rust formatter configuration for consistent code style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->